### PR TITLE
Remove requirement of pprint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setuptools.setup(
             'parse_xbrl=xbrl_parser.console_scripts.__main__:main',
         ]
     },
-    install_requires=["pprint"],
     extras_require={
         'lint': [
             "pylint",


### PR DESCRIPTION
pprint is a standard package of Python3.
And requirement of pprint in setup.py create errors.

This PR is related with [issue-6](https://github.com/dkfinance/xbrl-parser/issues/6).